### PR TITLE
Ensure hard restarts

### DIFF
--- a/lua/autorun/server/sv_daily_restart.lua
+++ b/lua/autorun/server/sv_daily_restart.lua
@@ -383,10 +383,10 @@ local function formatAlertMessage( msg, secondsUntilNextRestart )
     return msg .. "!"
 end
 
-local function onHardAlertTimeout()
+local function onHardAlertTimeout( forced )
     tryingToHardRestart = true
 
-    if os.time() < EARLIEST_RESTART_TIME then
+    if not forced and os.time() < EARLIEST_RESTART_TIME then
         -- If it's too early, then retry at the earliest possible time.
         timer.Create( DAILY_RESTART_TIMER_NAME, EARLIEST_RESTART_TIME - os.time() + 1, 1, onHardAlertTimeout )
 
@@ -556,6 +556,23 @@ function CFCDailyRestart.stopSoftRestart( ply, hidePrint )
 
     sendAlertToClients( "The soft restart has been canceled." )
 end
+
+
+local forcedHardRestartWithConcmd = false
+
+concommand.Add( "cfc_daily_restart_force_hard_restart", function( ply )
+    if IsValid( ply ) then return end -- Server console only.
+
+    if forcedHardRestartWithConcmd then
+        print( "The hard restart is already imminent!" )
+
+        return
+    end
+
+    forcedHardRestartWithConcmd = true
+
+    timer.Create( DAILY_RESTART_TIMER_NAME, 0, 1, onHardAlertTimeout )
+end )
 
 
 hook.Add( "MapVote_RTVStart", "CFC_DailyRestart_PreventNearHardRestarts", function()

--- a/lua/autorun/server/sv_daily_restart.lua
+++ b/lua/autorun/server/sv_daily_restart.lua
@@ -15,6 +15,7 @@ local ALERT_NOTIFICATION_ADMIN_NAME = "CFC_DailyRestartAlertAdmin"
 local TESTING_BOOLEAN = false
 
 local SOFT_RESTART_STOP_COMMAND = "!stoprestart"
+local SOFT_RESTART_USE_RTV = true
 local MINIMUM_HOURS_BEFORE_RESTART = 1 -- Hard restarts will wait until this many hours after map startup before they begin their alert and restart process.
 local RESTART_BUFFER = 5 -- Will only trigger a soft restart if it isn't scheduled to be within this many hours of the hard restart
 local SOFT_RESTART_WINDOWS = { -- { X, Y } = At X hours since game start, a changelevel will be blocked if there are at least Y-many players (i.e. lower numbers are less likely to succeed)
@@ -331,7 +332,19 @@ local function softRestartServer()
 
         hook.Run( "CFC_DailyRestart_SoftRestart" )
 
-        game.ConsoleCommand( "changelevel " .. game.GetMap() ..  "\n" )
+        -- Try to start an rtv instead of keeping the same map
+        if SOFT_RESTART_USE_RTV and MapVote and MapVote.state and not MapVote.state.isInProgres then
+            local voteDuration = 120
+
+            MapVote.Start( voteDuration )
+
+            -- In case the map vote is canceled for some reason.
+            timer.Create( SOFT_RESTART_TIMER_NAME, voteDuration + 20, 1, function()
+                game.ConsoleCommand( "changelevel " .. game.GetMap() ..  "\n" )
+            end )
+        else
+            game.ConsoleCommand( "changelevel " .. game.GetMap() ..  "\n" )
+        end
     else
         sendAlertToClients( "Soft-restarting server ( not really, this is a test )!" )
     end

--- a/lua/autorun/server/sv_daily_restart.lua
+++ b/lua/autorun/server/sv_daily_restart.lua
@@ -405,6 +405,7 @@ local function onHardAlertTimeout()
     tryAlertNotification( secondsUntilNextRestart, notifMsg )
 
     timer.Adjust( DAILY_RESTART_TIMER_NAME, secondsUntilNextAlert, 1, onHardAlertTimeout )
+    timer.Remove( SOFT_RESTART_TIMER_NAME ) -- Just in case
 end
 
 local function onSoftAlertTimeout()

--- a/lua/autorun/server/sv_daily_restart.lua
+++ b/lua/autorun/server/sv_daily_restart.lua
@@ -15,7 +15,7 @@ local ALERT_NOTIFICATION_ADMIN_NAME = "CFC_DailyRestartAlertAdmin"
 local TESTING_BOOLEAN = false
 
 local SOFT_RESTART_STOP_COMMAND = "!stoprestart"
-local MINIMUM_HOURS_BEFORE_RESTART = 3
+local MINIMUM_HOURS_BEFORE_RESTART = 1
 local RESTART_BUFFER = 5 -- Will only trigger a soft restart if it isn't scheduled to be within this many hours of the hard restart
 local SOFT_RESTART_WINDOWS = { -- { X, Y } = At X hours since game start, a changelevel will be blocked if there are at least Y-many players (i.e. lower numbers are less likely to succeed)
     {

--- a/lua/autorun/server/sv_daily_restart.lua
+++ b/lua/autorun/server/sv_daily_restart.lua
@@ -15,7 +15,7 @@ local ALERT_NOTIFICATION_ADMIN_NAME = "CFC_DailyRestartAlertAdmin"
 local TESTING_BOOLEAN = false
 
 local SOFT_RESTART_STOP_COMMAND = "!stoprestart"
-local MINIMUM_HOURS_BEFORE_RESTART = 1
+local MINIMUM_HOURS_BEFORE_RESTART = 1 -- Hard restarts will wait until this many hours after map startup before they begin their alert and restart process.
 local RESTART_BUFFER = 5 -- Will only trigger a soft restart if it isn't scheduled to be within this many hours of the hard restart
 local SOFT_RESTART_WINDOWS = { -- { X, Y } = At X hours since game start, a changelevel will be blocked if there are at least Y-many players (i.e. lower numbers are less likely to succeed)
     {

--- a/lua/autorun/server/sv_daily_restart.lua
+++ b/lua/autorun/server/sv_daily_restart.lua
@@ -148,6 +148,7 @@ end
 local AlertDeltas = {}
 local alertIntervalsInSeconds = {}
 local currentSoftRestartWindow = 1
+local tryingToHardRestart = false
 CFCDailyRestart.softRestartImminent = false
 CFCDailyRestart.softRestartSkippable = true
 CFCDailyRestart.numSoftStops = CFCDailyRestart.numSoftStops or 0
@@ -383,6 +384,8 @@ local function formatAlertMessage( msg, secondsUntilNextRestart )
 end
 
 local function onHardAlertTimeout()
+    tryingToHardRestart = true
+
     if os.time() < EARLIEST_RESTART_TIME then
         -- If it's too early, then retry at the earliest possible time.
         timer.Create( DAILY_RESTART_TIMER_NAME, EARLIEST_RESTART_TIME - os.time() + 1, 1, onHardAlertTimeout )
@@ -552,6 +555,11 @@ function CFCDailyRestart.stopSoftRestart( ply, hidePrint )
 
     sendAlertToClients( "The soft restart has been canceled." )
 end
+
+
+hook.Add( "MapVote_RTVStart", "CFC_DailyRestart_PreventNearHardRestarts", function()
+    if tryingToHardRestart then return false end
+end )
 
 if ULib then return end
 

--- a/lua/autorun/server/sv_daily_restart.lua
+++ b/lua/autorun/server/sv_daily_restart.lua
@@ -383,7 +383,13 @@ local function formatAlertMessage( msg, secondsUntilNextRestart )
 end
 
 local function onHardAlertTimeout()
-    if os.time() < EARLIEST_RESTART_TIME then return end
+    if os.time() < EARLIEST_RESTART_TIME then
+        -- If it's too early, then retry at the earliest possible time.
+        timer.Create( DAILY_RESTART_TIMER_NAME, EARLIEST_RESTART_TIME - os.time() + 1, 1, onHardAlertTimeout )
+
+        return
+    end
+
     if canRestartServer() then return restartServer() end
 
     local secondsUntilNextAlert, secondsUntilNextRestart = getSecondsUntilAlertAndRestart()


### PR DESCRIPTION
- Prevents recent map changes from disabling the hard restart entirely if it's scheduled to be within the minimum restart time since the map change.
- RTV is disabled when a hard restart is imminent.
- Adds a `cfc_daily_restart_force_hard_restart` server concmd to force a hard restart alert to begin.