### PR TITLE
Assorted fixes

### DIFF
--- a/lua/autorun/server/sv_daily_restart.lua
+++ b/lua/autorun/server/sv_daily_restart.lua
@@ -321,6 +321,12 @@ local function tryAlertNotification( secondsUntilNextRestart, msg, msgAdmin, noA
 end
 
 local function restartServer()
+    timer.Create( "CFC_DailyRestart_RestartFailed", 60, 1, function()
+        tryingToHardRestart = false -- Unbreak rtv.
+
+        -- TODO: Fallback restart method?
+    end )
+
     logWebhook( "Server hard restarting" )
     if not TESTING_BOOLEAN then
         sendAlertToClients( "Restarting server!" )

--- a/lua/autorun/server/sv_daily_restart.lua
+++ b/lua/autorun/server/sv_daily_restart.lua
@@ -475,16 +475,13 @@ local function waitUntilRestartHour()
     local timeTbl = os.date( "!*t" )
     local currentMinute = timeTbl.min
     local currentSecond =  timeTbl.sec
-
     local hoursLeft = getHoursUntilRestartHour()
 
-    local secondsOffset = 60 - currentSecond
-    local minutesOffset = 60 - currentMinute - 1
+    -- How far we are into the current hour
+    local secondsSpentInCurrentHour = currentMinute * 60 + currentSecond
 
-    -- We are this many seconds into the hour
-    local secondsAndMinutes = secondsOffset + ( minutesOffset * 60 )
-
-    local secondsToWait = ( hoursLeft * SECONDS_IN_HOUR ) - secondsAndMinutes
+    -- hoursLeft rounds up, so we need to take out the amount of time spent in the current hour
+    local secondsToWait = ( hoursLeft * SECONDS_IN_HOUR ) - secondsSpentInCurrentHour
 
     local timeToRestart = currentTime() + secondsToWait
     sendRestartTimeToClients( timeToRestart )

--- a/lua/autorun/server/sv_daily_restart.lua
+++ b/lua/autorun/server/sv_daily_restart.lua
@@ -169,17 +169,18 @@ if file.Exists( "includes/modules/webhooker_interface.lua", "LUA" ) then
     webhooker = WebhookerInterface()
 end
 
-local function logWebhook( str )
-    local tbl = {
-        source = "sv_daily_restart",
-        text = str,
-        AlertDeltas = AlertDeltas,
-        alertIntervalsInSeconds = alertIntervalsInSeconds,
-        EARLIEST_RESTART_TIME = EARLIEST_RESTART_TIME,
-        isOsTimeLarger = os.time() < EARLIEST_RESTART_TIME,
-        playersInServer = #player.GetHumans(),
-        allRestartAlertsGiven = table.Count( alertIntervalsInSeconds ) == 0
-    }
+local function logWebhookGeneric( info, isGood )
+    local tbl = table.Copy( info )
+    local diffChar = "|"
+
+    if isGood == true then
+        diffChar = "+"
+    elseif isGood == false then
+        diffChar = "-"
+    end
+
+    tbl.source = "sv_daily_restart"
+    tbl.webhookDescription = "```diff\n" .. diffChar .. " Daily Restart " .. diffChar .. "```"
 
     if not webhooker then
         PrintTable( tbl )
@@ -187,6 +188,18 @@ local function logWebhook( str )
     end
 
     webhooker:send( "testing-endpoint", tbl )
+end
+
+local function logWebhookRestart( str )
+    logWebhookGeneric( {
+        text = str,
+        AlertDeltas = AlertDeltas,
+        alertIntervalsInSeconds = alertIntervalsInSeconds,
+        EARLIEST_RESTART_TIME = EARLIEST_RESTART_TIME,
+        isOsTimeLarger = os.time() < EARLIEST_RESTART_TIME,
+        playersInServer = #player.GetHumans(),
+        allRestartAlertsGiven = table.Count( alertIntervalsInSeconds ) == 0
+    } )
 end
 
 local function mixpanelTrackEvent( eventName, data, reliable )
@@ -324,10 +337,14 @@ local function restartServer()
     timer.Create( "CFC_DailyRestart_RestartFailed", 60, 1, function()
         tryingToHardRestart = false -- Unbreak rtv.
 
+        logWebhookGeneric( {
+            text = "Hard restart failed!",
+        }, false )
+
         -- TODO: Fallback restart method?
     end )
 
-    logWebhook( "Server hard restarting" )
+    logWebhookRestart( "Server hard restarting" )
     if not TESTING_BOOLEAN then
         sendAlertToClients( "Restarting server!" )
         Restarter:restart()
@@ -337,7 +354,7 @@ local function restartServer()
 end
 
 local function softRestartServer()
-    logWebhook( "Server soft restarting" )
+    logWebhookRestart( "Server soft restarting" )
     if not TESTING_BOOLEAN then
         sendAlertToClients( "Soft-restarting server!" )
 

--- a/lua/autorun/server/sv_daily_restart.lua
+++ b/lua/autorun/server/sv_daily_restart.lua
@@ -6,7 +6,7 @@ local Restarter = CFCRestartLib()
 local DESIRED_RESTART_HOUR = 11 -- The hour to initiate a restart, in UTC time. Must be between 0-23
 local ACCEPTABLE_HOURS_BETWEEN_RESTARTS = 3 -- If the scheduled hard restart is within this many hours of the last hard restart, skip it.
 
-local RESTART_RETRY_ATTEMPS = 5 -- How many times to retry if the hard restart library fails.
+local RESTART_RETRY_ATTEMPTS = 5 -- How many times to retry if the hard restart library fails.
 local RESTART_RETRY_INTERVAL = 60 -- Seconds between hard restart retries.
 
 local DAILY_RESTART_TIMER_NAME = "CFC_DailyRestartTimer"
@@ -153,7 +153,7 @@ local AlertDeltas = {}
 local alertIntervalsInSeconds = {}
 local currentSoftRestartWindow = 1
 local tryingToHardRestart = false
-local restartAttemptsLeft = RESTART_RETRY_ATTEMPS
+local restartAttemptsLeft = RESTART_RETRY_ATTEMPTS
 CFCDailyRestart.softRestartImminent = false
 CFCDailyRestart.softRestartSkippable = true
 CFCDailyRestart.numSoftStops = CFCDailyRestart.numSoftStops or 0

--- a/lua/autorun/server/sv_daily_restart.lua
+++ b/lua/autorun/server/sv_daily_restart.lua
@@ -10,6 +10,9 @@ local RESTART_REDUNDANCY_SCHEDULE_HOURS = 2 -- From map startup, if the schedule
 local RESTART_REDUNDANCY_STARTUP_HOURS = 3 -- ... if the server has hard-restarted within this many hours, then...
 -- ... skip the restart since it effectively already happened today.
 
+local RESTART_RETRY_ATTEMPS = 5 -- How many times to retry if the hard restart library fails.
+local RESTART_RETRY_INTERVAL = 60 -- Seconds between hard restart retries.
+
 local DAILY_RESTART_TIMER_NAME = "CFC_DailyRestartTimer"
 local SOFT_RESTART_TIMER_NAME = "CFC_SoftRestartTimer"
 local ALERT_NOTIFICATION_NAME = "CFC_DailyRestartAlert"
@@ -155,6 +158,7 @@ local alertIntervalsInSeconds = {}
 local currentSoftRestartWindow = 1
 local tryingToHardRestart = false
 local restartIsRedundant = nil
+local restartAttemptsLeft = RESTART_RETRY_ATTEMPS
 CFCDailyRestart.softRestartImminent = false
 CFCDailyRestart.softRestartSkippable = true
 CFCDailyRestart.numSoftStops = CFCDailyRestart.numSoftStops or 0
@@ -335,24 +339,39 @@ local function tryAlertNotification( secondsUntilNextRestart, msg, msgAdmin, noA
     end
 end
 
+local function _restartServer()
+    ProtectedCall( function()
+        Restarter:restart()
+    end )
+end
+
 local function restartServer()
-    timer.Create( "CFC_DailyRestart_RestartFailed", 60, 1, function()
+    logWebhookRestart( "Server hard restarting" )
+
+    if TESTING_BOOLEAN then
+        sendAlertToClients( "Restarting server ( not really, this is a test )!" )
+        return
+    end
+
+    timer.Create( "CFC_DailyRestart_RetryRestart", RESTART_RETRY_INTERVAL, 0, function()
+        if restartAttemptsLeft > 0 then -- Retry.
+            restartAttemptsLeft = restartAttemptsLeft - 1
+            _restartServer()
+
+            return
+        end
+
         tryingToHardRestart = false -- Unbreak rtv.
 
         logWebhookGeneric( {
             text = "Hard restart failed!",
         }, false )
 
-        -- TODO: Fallback restart method?
+        timer.Remove( "CFC_DailyRestart_RetryRestart" )
     end )
 
-    logWebhookRestart( "Server hard restarting" )
-    if not TESTING_BOOLEAN then
-        sendAlertToClients( "Restarting server!" )
-        Restarter:restart()
-    else
-        sendAlertToClients( "Restarting server ( not really, this is a test )!" )
-    end
+    sendAlertToClients( "Restarting server!" )
+    _restartServer()
 end
 
 local function softRestartServer()

--- a/lua/autorun/server/sv_daily_restart.lua
+++ b/lua/autorun/server/sv_daily_restart.lua
@@ -6,7 +6,7 @@ CFCDailyRestart = CFCDailyRestart or {}
 local Restarter = CFCRestartLib()
 local DESIRED_RESTART_HOUR = 11 -- The hour to initiate a restart, in UTC time. Must be between 0-23
 
-local RESTART_REDUNDANCY_SCHEDULE_HOURS = 2 -- If the scheduled hard restart is within this many hours, and...
+local RESTART_REDUNDANCY_SCHEDULE_HOURS = 2 -- From map startup, if the scheduled hard restart is within this many hours, and...
 local RESTART_REDUNDANCY_STARTUP_HOURS = 3 -- ... if the server has hard-restarted within this many hours, then...
 -- ... skip the restart since it effectively already happened today.
 
@@ -154,6 +154,7 @@ local AlertDeltas = {}
 local alertIntervalsInSeconds = {}
 local currentSoftRestartWindow = 1
 local tryingToHardRestart = false
+local restartIsRedundant = nil
 CFCDailyRestart.softRestartImminent = false
 CFCDailyRestart.softRestartSkippable = true
 CFCDailyRestart.numSoftStops = CFCDailyRestart.numSoftStops or 0
@@ -456,6 +457,26 @@ local function onSoftAlertTimeout()
     timer.Create( SOFT_RESTART_TIMER_NAME, secondsUntilNextAlert, 1, onSoftAlertTimeout )
 end
 
+-- Caches the result on first call, since there is a sweet spot where it could initially be false, then later true as time passes.
+-- The hard restart timer is made on startup, so the cache ensures everything stays consistent with that first check.
+local function doRestartRedundancyCheck( hoursLeft )
+    if restartIsRedundant ~= nil then return restartIsRedundant end
+
+    restartIsRedundant = false
+
+    -- If the scheduled restart is soon...
+    if hoursLeft > RESTART_REDUNDANCY_SCHEDULE_HOURS then
+        local timeSinceLastHardRestart = os.time() - SysTime()
+
+        -- If the server hard-restarted recently, there's no need to do the scheduled one today.
+        if timeSinceLastHardRestart < RESTART_REDUNDANCY_STARTUP_HOURS * SECONDS_IN_HOUR then
+            restartIsRedundant = true
+        end
+    end
+
+    return restartIsRedundant
+end
+
 local function getHoursUntilRestartHour()
     local hoursLeft = 24
     local restartHour = DESIRED_RESTART_HOUR
@@ -467,14 +488,8 @@ local function getHoursUntilRestartHour()
         hoursLeft = ( 24 - currentHour ) + restartHour
     end
 
-    -- Anti-reduncancy check.
-    if hoursLeft <= RESTART_REDUNDANCY_SCHEDULE_HOURS then
-        local timeSinceLastHardRestart = os.time() - SysTime()
-
-        -- If the server hard-restarted recently, there's no need to do the scheduled one today.
-        if timeSinceLastHardRestart < RESTART_REDUNDANCY_STARTUP_HOURS * SECONDS_IN_HOUR then
-            hoursLeft = hoursLeft + 24
-        end
+    if doRestartRedundancyCheck( hoursLeft ) then
+        hoursLeft = hoursLeft + 24
     end
 
     return hoursLeft

--- a/lua/autorun/server/sv_daily_restart.lua
+++ b/lua/autorun/server/sv_daily_restart.lua
@@ -4,10 +4,7 @@ CFCDailyRestart = CFCDailyRestart or {}
 
 local Restarter = CFCRestartLib()
 local DESIRED_RESTART_HOUR = 11 -- The hour to initiate a restart, in UTC time. Must be between 0-23
-
-local RESTART_REDUNDANCY_SCHEDULE_HOURS = 2 -- From map startup, if the scheduled hard restart is within this many hours, and...
-local RESTART_REDUNDANCY_STARTUP_HOURS = 3 -- ... if the server has hard-restarted within this many hours, then...
--- ... skip the restart since it effectively already happened today.
+local ACCEPTABLE_HOURS_BETWEEN_RESTARTS = 3 -- If the scheduled hard restart is within this many hours of the last hard restart, skip it.
 
 local RESTART_RETRY_ATTEMPS = 5 -- How many times to retry if the hard restart library fails.
 local RESTART_RETRY_INTERVAL = 60 -- Seconds between hard restart retries.
@@ -156,7 +153,6 @@ local AlertDeltas = {}
 local alertIntervalsInSeconds = {}
 local currentSoftRestartWindow = 1
 local tryingToHardRestart = false
-local restartIsRedundant = nil
 local restartAttemptsLeft = RESTART_RETRY_ATTEMPS
 CFCDailyRestart.softRestartImminent = false
 CFCDailyRestart.softRestartSkippable = true
@@ -492,26 +488,6 @@ local function onSoftAlertTimeout()
     timer.Create( SOFT_RESTART_TIMER_NAME, secondsUntilNextAlert, 1, onSoftAlertTimeout )
 end
 
--- Caches the result on first call, since there is a sweet spot where it could initially be false, then later true as time passes.
--- The hard restart timer is made on startup, so the cache ensures everything stays consistent with that first check.
-local function doRestartRedundancyCheck( hoursLeft )
-    if restartIsRedundant ~= nil then return restartIsRedundant end
-
-    restartIsRedundant = false
-
-    -- If the scheduled restart is soon...
-    if hoursLeft > RESTART_REDUNDANCY_SCHEDULE_HOURS then
-        local timeSinceLastHardRestart = os.time() - SysTime()
-
-        -- If the server hard-restarted recently, there's no need to do the scheduled one today.
-        if timeSinceLastHardRestart < RESTART_REDUNDANCY_STARTUP_HOURS * SECONDS_IN_HOUR then
-            restartIsRedundant = true
-        end
-    end
-
-    return restartIsRedundant
-end
-
 local function getHoursUntilRestartHour()
     local hoursLeft = 24
     local restartHour = DESIRED_RESTART_HOUR
@@ -523,7 +499,13 @@ local function getHoursUntilRestartHour()
         hoursLeft = ( 24 - currentHour ) + restartHour
     end
 
-    if doRestartRedundancyCheck( hoursLeft ) then
+    -- Approximate to the hour. Same as nextRestartTime - lastRestartTime, where
+    --  nextRestartTime = os.time() + hoursLeft * SECONDS_IN_HOUR
+    --  lastRestartTime = os.time() - SysTime()
+    local gapBetweenLastAndNextRestarts = SysTime() + hoursLeft * SECONDS_IN_HOUR
+
+    -- If the previous restart happened too close to when the next one is scheduled, treat it as though today's restart already happened.
+    if gapBetweenLastAndNextRestarts < ACCEPTABLE_HOURS_BETWEEN_RESTARTS * SECONDS_IN_HOUR then
         hoursLeft = hoursLeft + 24
     end
 

--- a/lua/autorun/server/sv_daily_restart.lua
+++ b/lua/autorun/server/sv_daily_restart.lua
@@ -6,6 +6,10 @@ CFCDailyRestart = CFCDailyRestart or {}
 local Restarter = CFCRestartLib()
 local DESIRED_RESTART_HOUR = 11 -- The hour to initiate a restart, in UTC time. Must be between 0-23
 
+local RESTART_REDUNDANCY_SCHEDULE_HOURS = 2 -- If the scheduled hard restart is within this many hours, and...
+local RESTART_REDUNDANCY_STARTUP_HOURS = 3 -- ... if the server has hard-restarted within this many hours, then...
+-- ... skip the restart since it effectively already happened today.
+
 local DAILY_RESTART_TIMER_NAME = "CFC_DailyRestartTimer"
 local SOFT_RESTART_TIMER_NAME = "CFC_SoftRestartTimer"
 local ALERT_NOTIFICATION_NAME = "CFC_DailyRestartAlert"
@@ -461,6 +465,16 @@ local function getHoursUntilRestartHour()
         hoursLeft = restartHour - currentHour
     elseif currentHour > restartHour then
         hoursLeft = ( 24 - currentHour ) + restartHour
+    end
+
+    -- Anti-reduncancy check.
+    if hoursLeft <= RESTART_REDUNDANCY_SCHEDULE_HOURS then
+        local timeSinceLastHardRestart = os.time() - SysTime()
+
+        -- If the server hard-restarted recently, there's no need to do the scheduled one today.
+        if timeSinceLastHardRestart < RESTART_REDUNDANCY_STARTUP_HOURS * SECONDS_IN_HOUR then
+            hoursLeft = hoursLeft + 24
+        end
     end
 
     return hoursLeft

--- a/lua/autorun/server/sv_daily_restart.lua
+++ b/lua/autorun/server/sv_daily_restart.lua
@@ -187,7 +187,9 @@ local function logWebhookGeneric( info, isGood )
         return
     end
 
-    webhooker:send( "testing-endpoint", tbl )
+    ProtectedCall( function()
+        webhooker:send( "testing-endpoint", tbl )
+    end )
 end
 
 local function logWebhookRestart( str )

--- a/lua/autorun/server/sv_daily_restart.lua
+++ b/lua/autorun/server/sv_daily_restart.lua
@@ -1,5 +1,4 @@
 require( "cfc_restart_lib" )
-util.AddNetworkString( "AlertUsersOfRestart" )
 
 CFCDailyRestart = CFCDailyRestart or {}
 
@@ -240,8 +239,6 @@ local function secondsToMinutes( minutes )
       return math.floor( minutes / SECONDS_IN_MINUTE )
 end
 
-local currentTime = os.time
-
 -- END HELPERS --
 
 
@@ -285,12 +282,6 @@ local function splitPlayersBySoftRestartStopAccess()
     end
 
     return noAccess, hasAccess
-end
-
-local function sendRestartTimeToClients( timeOfRestart )
-    net.Start( "AlertUsersOfRestart" )
-        net.WriteFloat( timeOfRestart )
-    net.Broadcast()
 end
 
 local function newAlertNotification( notifID, msg, duration )
@@ -555,9 +546,6 @@ local function waitUntilRestartHour()
 
     -- hoursLeft rounds up, so we need to take out the amount of time spent in the current hour
     local secondsToWait = ( hoursLeft * SECONDS_IN_HOUR ) - secondsSpentInCurrentHour
-
-    local timeToRestart = currentTime() + secondsToWait
-    sendRestartTimeToClients( timeToRestart )
 
     createRestartTimer( secondsToWait )
 end


### PR DESCRIPTION
- Fixes hard restart timer math (e.g. if currently 4:10 and scheduled for 6:00, old math waited for 1h10m instead of 1h50m)
  - The old, incorrect math often caused two restarts to happen close together each day.
- Skips today's daily restart if the map starts close to its scheduled time and the server recently hard-restarted.
  - This prevents time imprecision from causing double restarts the same way the old math used to.
  - This also stops redundant restarts if the server recently crashed or had a manual restart.
- Puts `ProtectedCall` around webhooker and restarter calls.
  - I doubt they were ever throwing errors, but it's simply good practice when a module like this cannot be permitted to fail.
- Sets a proper webhooker description instead of letting the default apply.
- Hard restarts now retry five times, at one-minute intervals.
- If all hard restart retries fail, the rtv block will be disabled so the server doesn't get stuck.